### PR TITLE
Add the article 'parts' subdivision, as marked on the TODO list

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,14 @@ data = first_step.as_dict()
 how_to.print(extended=True)
 
 ```
+Some articles have their topics subdivided into internal parts. The parent part of each step is kept on the field `part` of the step.
+
+```python
+print(first_step.part)
+```
 
 ### ToDo
 
-- Many WikiHow articles also contain "Parts" which break down further into sub-steps. Write a function to parse these additional divisions.
+
 - Add parser for tips
 - Add parser for warnings

--- a/pywikihow/__init__.py
+++ b/pywikihow/__init__.py
@@ -17,12 +17,13 @@ def get_html(url):
 
 
 class HowToStep:
-    def __init__(self, number, summary=None, description=None, picture=None, part=None):
+    def __init__(self, number, summary=None, description=None, picture=None, part=None, title=None):
         self._number = number
         self._summary = summary
         self._description = description
         self._picture = picture
         self._part = part
+        self._title = title
 
     @property
     def number(self):
@@ -44,12 +45,17 @@ class HowToStep:
     def part(self):
         return self._part
 
+    @property
+    def title(self):
+        return self._title
+
     def as_dict(self):
         return {"number": self.number,
                 "summary": self.summary,
                 "description": self.description,
                 "picture": self.picture,
-                "part": self.part}
+                "part": self.part,
+                "title": self.title}
 
     def print(self, extended=False):
         print(self.number, "-", self.summary)
@@ -147,6 +153,7 @@ class HowTo:
         self._steps = []
         stickys = soup.find_all("div", re.compile("section steps.*sticky"))
         for sticky in stickys:
+            stick_title = sticky.find("span", {"class": "mw-headline"})
             stick_name = sticky.find("div", {"class": "altblock"}).text.strip()
             step_html = sticky.find_all("div", {"class": "step"})
             for (html_count, html) in enumerate(step_html):
@@ -167,6 +174,8 @@ class HowTo:
                 for b in ex_step.find_all("b"):
                     b.decompose()
                 step._description = ex_step.text.strip()
+                if stick_name:
+                    step._title = stick_title.text.strip()
                 self._steps.append(step)
 
     def _parse_pictures(self, soup):

--- a/pywikihow/__init__.py
+++ b/pywikihow/__init__.py
@@ -154,7 +154,11 @@ class HowTo:
         stickys = soup.find_all("div", re.compile("section steps.*sticky"))
         for sticky in stickys:
             stick_title = sticky.find("span", {"class": "mw-headline"})
-            stick_name = sticky.find("div", {"class": "altblock"}).text.strip()
+            stick_name = sticky.find("div", {"class": "altblock"})
+            if not stick_name:
+                stick_name = ''
+            else:
+                stick_name = stick_name.text.strip()
             step_html = sticky.find_all("div", {"class": "step"})
             for (html_count, html) in enumerate(step_html):
                 # This finds and cleans weird tags from the step data
@@ -275,14 +279,14 @@ def search_wikihow(query, max_results=10, lang="en"):
 
 
 if __name__ == "__main__":
-    how = HowTo('https://pt.wikihow.com/Fazer-Comida-Para-Cachorro', lazy=False)
-    how = RandomHowTo("it")
-    how.print()
+    how = HowTo('https://pt.wikihow.com/Contar-C%C3%A9lulas-no-Google-Planilhas-no-Windows-ou-Mac', lazy=False)
+    # how = RandomHowTo("it")
+    # how.print()
 
-    for how_to in WikiHow.search("comprar bitcoin", lang="pt"):
-        how_to.print()
-        break
+    # for how_to in WikiHow.search("comprar bitcoin", lang="pt"):
+    #     how_to.print()
+    #     break
 
-    for how_to in WikiHow.search("buy bitcoin"):
-        how_to.print()
-        break
+    # for how_to in WikiHow.search("buy bitcoin"):
+    #     how_to.print()
+    #     break

--- a/pywikihow/__init__.py
+++ b/pywikihow/__init__.py
@@ -1,3 +1,4 @@
+import re
 import bs4
 from pywikihow.exceptions import ParseError, UnsupportedLanguage
 from datetime import timedelta
@@ -16,11 +17,12 @@ def get_html(url):
 
 
 class HowToStep:
-    def __init__(self, number, summary=None, description=None, picture=None):
+    def __init__(self, number, summary=None, description=None, picture=None, part=None):
         self._number = number
         self._summary = summary
         self._description = description
         self._picture = picture
+        self._part = part
 
     @property
     def number(self):
@@ -38,11 +40,16 @@ class HowToStep:
     def picture(self):
         return self._picture
 
+    @property
+    def part(self):
+        return self._part
+
     def as_dict(self):
         return {"number": self.number,
                 "summary": self.summary,
                 "description": self.description,
-                "picture": self.picture}
+                "picture": self.picture,
+                "part": self.part}
 
     def print(self, extended=False):
         print(self.number, "-", self.summary)
@@ -110,7 +117,7 @@ class HowTo:
 
     def _parse_title(self, soup):
         # get title
-        html = soup.findAll("h1",
+        html = soup.find_all("h1",
                             {"class": ["title_lg", "title_md", "title_sm"]})[0]
         if not html.find("a"):
             raise ParseError
@@ -126,9 +133,9 @@ class HowTo:
         if not intro_html:
             raise ParseError
         else:
-            super = intro_html.find("sup")
-            if super != None:
-                for sup in intro_html.findAll("sup"):
+            sup = intro_html.find("sup")
+            if sup:
+                for sup in intro_html.find_all("sup"):
                     sup.decompose()
                     intro = intro_html.text
                     self._intro = intro.strip()
@@ -138,35 +145,37 @@ class HowTo:
 
     def _parse_steps(self, soup):
         self._steps = []
-        step_html = soup.findAll("div", {"class": "step"})
-        count = 0
-        for html in step_html:
-            # This finds and cleans weird tags from the step data
-            super = html.find("sup")
-            script = html.find("script")
-            if script != None:
-                for script in html.findAll("script"):
-                    script.decompose()
-            if super != None:
-                for sup in html.findAll("sup"):
-                    sup.decompose()
-            count += 1
-            summary = html.find("b").text
+        stickys = soup.find_all("div", re.compile("section steps.*sticky"))
+        for sticky in stickys:
+            stick_name = sticky.find("div", {"class": "altblock"}).text.strip()
+            step_html = sticky.find_all("div", {"class": "step"})
+            for (html_count, html) in enumerate(step_html):
+                # This finds and cleans weird tags from the step data
+                if html.script:
+                    for script in html.find_all("script"):
+                        script.decompose()
+                if html.sup:
+                    for sup in html.find_all("sup"):
+                        sup.decompose()
+                try:
+                    summary = html.find("b").text
+                except:
+                    breakpoint()
 
-            for _extra_div in html.find("b").find_all("div"):
-                summary = summary.replace(_extra_div.text, "")
+                for _extra_div in html.find("b").find_all("div"):
+                    summary = summary.replace(_extra_div.text, "")
 
-            step = HowToStep(count, summary)
-            ex_step = html
-            for b in ex_step.findAll("b"):
-                b.decompose()
-            step._description = ex_step.text.strip()
-            self._steps.append(step)
+                step = HowToStep(html_count, summary, part=stick_name)
+                ex_step = html
+                for b in ex_step.find_all("b"):
+                    b.decompose()
+                step._description = ex_step.text.strip()
+                self._steps.append(step)
 
     def _parse_pictures(self, soup):
         # get step pic
         count = 0
-        for html in soup.findAll("a", {"class": "image"}):
+        for html in soup.find_all("a", {"class": "image"}):
             # one more ugly blob, nice :D
             html = html.find("img")
             i = str(html).find("data-src=")
@@ -237,7 +246,7 @@ class WikiHow:
         search_url = WikiHow.lang2url[lang] + \
                      "wikiHowTo?search=" + search_term.replace(" ", "+")
         html = get_html(search_url)
-        soup = bs4.BeautifulSoup(html, 'html.parser').findAll('a', attrs={
+        soup = bs4.BeautifulSoup(html, 'html.parser').find_all('a', attrs={
             'class': "result_link"})
         count = 1
         for link in soup:
@@ -260,6 +269,7 @@ def search_wikihow(query, max_results=10, lang="en"):
 
 
 if __name__ == "__main__":
+    how = HowTo('https://pt.wikihow.com/Fazer-Comida-Para-Cachorro', lazy=False)
     how = RandomHowTo("it")
     how.print()
 

--- a/pywikihow/__init__.py
+++ b/pywikihow/__init__.py
@@ -157,10 +157,7 @@ class HowTo:
                 if html.sup:
                     for sup in html.find_all("sup"):
                         sup.decompose()
-                try:
-                    summary = html.find("b").text
-                except:
-                    breakpoint()
+                summary = html.find("b").text
 
                 for _extra_div in html.find("b").find_all("div"):
                     summary = summary.replace(_extra_div.text, "")


### PR DESCRIPTION
This PR solves the following problem which is cited on the TODO list
>Many WikiHow articles also contain "Parts" which break down further into sub-steps. Write a function to parse these additional divisions.

Now the Step object has a field 'part' which keeps the name of the "parent topic" of that object

Example:
Let's say we have an article on this format

Part 1
Step1=Do A
Step2=Do B

Part 2
Step3=Do C
Step4=Do D

Then we can use the package normally, but when accessing 'step1' we can check where it lives using step1.part, which in this case is 'Part 1'. The same result would fetched when calling 'step2.part'