### PR TITLE
docs: QA pass — accuracy, org-move URLs, related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ PyWikiHow is an unofficial Python API for WikiHow. It uses BeautifulSoup to scra
   * [Random How To](#random-how-to)
   * [Searching](#searching)
   * [Parsing](#parsing)
-- [Related projects](#related-projects)
 - [License](#license)
 
 ## Installation
@@ -83,10 +82,6 @@ print(first_step.part)
 
 - Add parser for tips
 - Add parser for warnings
-
-## Related projects
-
-- [TigreGotico/ovos-skill-wikihow](https://github.com/TigreGotico/ovos-skill-wikihow) — an OpenVoiceOS skill that uses this library to answer "how to" questions.
 
 ## License
 

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     name='pywikihow',
     version=get_version(),
     packages=['pywikihow'],
-    url='https://github.com/OpenJarbas/PyWikiHow',
+    url='https://github.com/LeMetadatarr/PyWikiHow',
     install_requires=required('requirements.txt'),
     license='MIT',
     author='jarbasai',


### PR DESCRIPTION
- `setup.py` `url=` pointed to `OpenJarbas/PyWikiHow` (pre-org-move). Updated to `https://github.com/LeMetadatarr/PyWikiHow`.
- README's "Related projects" section linked `TigreGotico/ovos-skill-wikihow`. That repo no longer exists under TigreGotico or LeMetadatarr (404, absent from both org repo listings). Removed the dead link and its table-of-contents entry rather than point at a broken URL.
- Verified README and examples/ against the current `pywikihow` package (`HowTo`, `HowToStep`, `RandomHowTo`, `WikiHow.search`, `search_wikihow`) — all install commands, imports, and usage snippets already match the source, no other changes needed.

Model usage: Claude (sonnet) authored these changes.